### PR TITLE
fix(config): read HTTP Basic credentials from Rails credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- HTTP Basic credentials set in Rails credentials are now read correctly. Rails
+  returns them as an `ActiveSupport::OrderedOptions`, which Flightdeck mistook
+  for a callable and resolved to nothing, leaving the dashboard unconfigured.
+
 ## [1.1.0] - 2026-08-12
 
 ### Added

--- a/lib/flightdeck/configuration.rb
+++ b/lib/flightdeck/configuration.rb
@@ -73,7 +73,11 @@ module Flightdeck
       def normalize(source)
         return nil if source.nil?
 
-        source = source.call if source.respond_to?(:call)
+        # Only genuine callables are invoked. `respond_to?(:call)` is not a safe
+        # test here: Rails credentials hand back an ActiveSupport::OrderedOptions,
+        # whose method_missing answers true for every name and returns nil for
+        # `call` — which used to swallow credential-configured auth entirely.
+        source = source.call if source.is_a?(Proc) || source.is_a?(Method)
         return nil if source.nil?
 
         username = fetch(source, :username)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -92,6 +92,27 @@ class Flightdeck::ConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "resolve_http_basic reads credentials returned as OrderedOptions" do
+    # This is what Rails actually hands back for a nested credentials key, and
+    # it claims to respond_to?(:call) for every name.
+    credentials = ActiveSupport::OrderedOptions.new
+    credentials.username = "cred"
+    credentials.password = "secret"
+
+    Rails.application.credentials.stub(:flightdeck, credentials) do
+      assert_equal({ username: "cred", password: "secret" }, @config.resolve_http_basic)
+    end
+  end
+
+  test "resolve_http_basic reads explicit http_basic given as OrderedOptions" do
+    @config.http_basic = ActiveSupport::OrderedOptions.new.tap do |options|
+      options.username = "a"
+      options.password = "b"
+    end
+
+    assert_equal({ username: "a", password: "b" }, @config.resolve_http_basic)
+  end
+
   test "base_controller_class defaults to ActionController::Base and constantizes when set" do
     # Load the controller while nothing is configured, so this test cannot
     # leave a half-defined constant behind for the rest of the suite.


### PR DESCRIPTION
## Summary

- Fixes #7: HTTP Basic credentials configured in Rails credentials were silently ignored, leaving Flightdeck serving its "unconfigured" 401.
- Rails hands back a nested credentials key as an `ActiveSupport::OrderedOptions` (`EncryptedConfiguration#deep_transform`). Its `method_missing` answers `respond_to?(:call)` with `true` for any name and returns `nil` for `call`, so `Configuration#normalize` invoked it and threw the credentials away.
- `normalize` now only invokes genuine callables (`Proc`/`Method`). The documented lambda support for rotating secrets is unchanged; the same bug also affected an explicit `config.http_basic` assigned an `OrderedOptions`.
- Adds regression tests for both paths (credentials source and explicit `http_basic`), plus a `[Unreleased] / Fixed` changelog entry. No version bump, no asset changes.

## Testing

- `bin/test` — 279 runs, 0 failures in both host modes (default and API-only)
- `bundle exec rubocop --force-exclusion lib/flightdeck/configuration.rb test/configuration_test.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
